### PR TITLE
Fix compiler issue for gcc>=6

### DIFF
--- a/environment/archive_binary_in.hpp
+++ b/environment/archive_binary_in.hpp
@@ -124,6 +124,9 @@ void ArchiveBinaryIn::read(std::map<TKey,TValue>& map) {
     }
 }
 
+template<typename T>
+ArchiveBinaryIn& operator%(ArchiveBinaryIn& ar,T& value);
+
 template<>
 inline ArchiveBinaryIn& operator%(ArchiveBinaryIn& ar,int& value) { ar.readPrimitive(value); return ar; }
 

--- a/environment/archive_binary_out.hpp
+++ b/environment/archive_binary_out.hpp
@@ -86,7 +86,7 @@ void ArchiveBinaryOut::writePrimitive(const T& value)
 }
 
 /**
- * Generic write vector 
+ * Generic write vector
  */
 template<typename T>
 void ArchiveBinaryOut::write(const std::vector<T>& value) {
@@ -120,6 +120,9 @@ void ArchiveBinaryOut::write(const std::map<TKey,TValue>& map) {
 /**
  * Generic write primitive function.
  */
+template<typename T>
+ArchiveBinaryOut& operator%(ArchiveBinaryOut& ar,const T& value);
+
 template<>
 inline ArchiveBinaryOut& operator%(ArchiveBinaryOut& ar,const int& value) { ar.writePrimitive(value); return ar; }
 


### PR DESCRIPTION
According to the specification, defining friend function template inside class does not make the name visible.
gcc<6 somehow doesn't complain about it.

See more discussion at https://gcc.gnu.org/bugzilla/show_bug.cgi?id=71227.
